### PR TITLE
isort should run sync

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -22,7 +22,7 @@ module.exports =
       pi.sortImports()
 
     atom.commands.add 'atom-workspace', 'python-isort:checkImports', ->
-      pi.checkImports()
+      pi.sortImports({save: false})
 
     atom.config.observe 'python-isort.sortOnSave', (value) ->
       atom.workspace.observeTextEditors (editor) ->
@@ -34,6 +34,6 @@ module.exports =
     atom.config.observe 'python-isort.checkOnSave', (value) ->
       atom.workspace.observeTextEditors (editor) ->
         if value == true
-          editor._isortCheck = editor.onDidSave -> pi.checkImports()
+          editor._isortCheck = editor.onDidSave -> pi.sortImports({save: false})
         else
           editor._isortCheck?.dispose()


### PR DESCRIPTION
I wrote atom-python-autopep8 which is based on your plugin and felt that it sometimes conflicted. I figured this is because it ran on the same file at the same time. So I did the following changes
- isort always runs sync
- merged check and `checkImports` and `sortImports` methods as they have lots of code overlap
- removed the which, if the command does not exists it will definitely return a not zero exit code
