### PR TITLE
Allow for other python language packages.

### DIFF
--- a/lib/python-isort.coffee
+++ b/lib/python-isort.coffee
@@ -6,10 +6,9 @@ module.exports =
 class PythonIsort
 
   checkForPythonContext: ->
-    editor = atom.workspace.getActiveTextEditor()
-    if not editor?
-      return false
-    return editor.getGrammar().scopeName == 'source.python'
+    grammar = atom.workspace.getActiveTextEditor()?.getGrammar?()
+    if grammar? and ~grammar.name.indexOf('Python')
+        return true
 
   removeStatusbarItem: =>
     @statusBarTile?.destroy()


### PR DESCRIPTION
This wasn't working with MagicPython (https://github.com/MagicStack/MagicPython), (or 'Python Django' for that matter). This PR takes care of that by making the `checkForPythonContext` more permissible.
