### PR TITLE
Support MagicPython grammar.

### DIFF
--- a/lib/python-isort.coffee
+++ b/lib/python-isort.coffee
@@ -9,7 +9,7 @@ class PythonIsort
     editor = atom.workspace.getActiveTextEditor()
     if not editor?
       return false
-    return editor.getGrammar().name == 'Python'
+    return editor.getGrammar().scopeName == 'source.python'
 
   removeStatusbarItem: =>
     @statusBarTile?.destroy()


### PR DESCRIPTION
Using `.name` when [`MagicPython`](https://atom.io/packages/magicpython) is installed yields `"MagicPython"`. This is different than what the default grammar `language-python` yields. This causes this package to fail to execute when using `MagicPython`. Prefer `.scopeName` which should always be `"source.python"` no matter what.